### PR TITLE
Optional field 'keyvalues' to associate free values to a requirement

### DIFF
--- a/python/speky/__main__.py
+++ b/python/speky/__main__.py
@@ -95,7 +95,7 @@ class SpecItem(SimpleNamespace):
 
 class Requirement(SpecItem):
     folder = 'requirements'
-    fields = SpecItem.fields + ['tags', 'client_statement']
+    fields = SpecItem.fields + ['tags', 'client_statement', 'keyvalues']
 
 class Test(SpecItem):
     folder = 'tests'

--- a/python/speky/generators/markdown.py
+++ b/python/speky/generators/markdown.py
@@ -79,13 +79,14 @@ class MarkdownCodeBlock(MystEnvironment):
 class Dropdown(MystEnvironment):
     name = 'dropdown'
 
-    def __init__(self, height: int, output: MarkdownWriter, title: str, color: str, opened: bool, icon: str | None = None):
+    def __init__(self, height: int, output: MarkdownWriter, title: str, opened: bool, color: str | None = None, icon: str | None = None):
         super().__init__(output, title, height)
         if opened:
             self.args['open'] = ''
         if icon:
             self.args['icon'] = icon
-        self.args['color'] = color
+        if color:
+            self.args['color'] = color
 
 class TableOfContent(MystEnvironment):
     name = 'toctree'
@@ -132,7 +133,7 @@ class MystWriter(MarkdownWriter):
         super().quote(quote_lines)
 
     def dropdown(self, height, title, color, opened, icon):
-        return Dropdown(height, self, title, color, opened, icon)
+        return Dropdown(height, self, title, opened, color, icon)
 
     def table_of_content(self, max_depth = None):
         return TableOfContent(self, max_depth = max_depth)
@@ -211,6 +212,13 @@ def requirement_to_myst(self, output: MystWriter, specs):
 
     if self.client_statement:
         output.quote(self.client_statement.split('\n'))
+    if self.keyvalues:
+        with output.dropdown(0, "Associated values", None, False, "note") as dropdown:
+            for item in self.keyvalues:
+                key = next(iter(item))
+                output.write_line(f"- {key}: {item[key]}")
+        output.empty_line()
+
     output.empty_line()
     output.write_line(self.long)
     output.empty_line()

--- a/specs/functional.yaml
+++ b/specs/functional.yaml
@@ -75,3 +75,11 @@ requirements:
 
     The `external` column must contain booleans, either `true`, `false`, `1` or `0`.
   tags: [input]
+- id: SF011
+  short: "Support having free key:value"
+  client_statement: We may associate a version to our statement, as well as an author
+  long: The user shall be able to associate many free "key:value" appearing next to the requirement
+  tags: [input, outputs]
+  keyvalues:
+    - version: 1
+    - author: Gloutch

--- a/sphinx/Makefile
+++ b/sphinx/Makefile
@@ -31,4 +31,5 @@ $(MarkdownIndex): $(YamlSources) $(PythonSources) $(CSVComments)
 		--project-name Speky
 
 $(SphinxHtml): $(MarkdownIndex) conf.py Makefile
-	$(Sphinx) -M html $(MarkdownFolder) $(SphinxFolder) --conf-dir . --nitpicky
+	$(Sphinx) -M html $(MarkdownFolder) $(SphinxFolder) \
+		--conf-dir . --nitpicky --jobs auto


### PR DESCRIPTION
Add an optional field to a requirement to store additional key:value.
 
The `keyvalues` field is a list of one element structure
```yaml
keyvalues:
  - version: 1
  - author: Gloutch
```
Note: I didn't bother checking the structure has exactly one element because I have plan to implement a more consistent check on all YAML input file

Then the list appears in a dropdown box between the client statement and the `long` text