### PR TITLE
Add --version option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ pattern = "(?P<base>\\d+[.]\\d+[.]\\d+)"
 [tool.uv]
 required-version = ">= 0.7.0"
 package = true
+cache-keys = [{ file = "pyproject.toml" }, { git = { commit = true, tags = true }}]
 
 [tool.ruff]
 line-length = 120

--- a/python/speky/__main__.py
+++ b/python/speky/__main__.py
@@ -3,6 +3,7 @@ import csv
 import datetime
 import logging
 from collections import defaultdict
+from importlib.metadata import version
 from types import SimpleNamespace
 
 import yaml
@@ -18,6 +19,7 @@ def main():
         description="Write your project's specification in YAML, display it as a static website",
         epilog='Copyright (c) 2025 Antoine  GAGNIERE',
     )
+    cli_parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + version(__package__))
     cli_parser.add_argument(
         'paths',
         type=str,


### PR DESCRIPTION
Somewhere I've bumped speky and missed a `--version` option, so here it is.
The pyproject.toml changes are from [uv-dynamic-versioning/tips](https://github.com/ninoseki/uv-dynamic-versioning/blob/main/docs/tips.md#build-caching-and-editable-installs)

For instance on this branch
```
$ uv run speky --version
Speky 0.1.0.post1.dev0+89eaed1
```