### PR TITLE
Claude plugin and LLM skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "speky",
+  "owner": { "name": "Antoine GAGNIERE" },
+  "plugins": [
+    {
+      "name": "speky",
+      "description": "Speky requirements and test specification manager with usage guidelines",
+      "source": {
+        "source": "github",
+        "repo": "agagniere/speky",
+        "ref": "plugin"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "speky",
+  "description": "Speky requirements and test specification manager",
+  "version": "0.4.0",
+  "author": { "name": "Antoine GAGNIERE" }
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "speky",
   "description": "Speky requirements and test specification manager",
-  "version": "0.4.0",
+  "version": "0.3.3-dev",
   "author": { "name": "Antoine GAGNIERE" }
 }

--- a/MCP.md
+++ b/MCP.md
@@ -264,6 +264,45 @@ List all requirements and tests that reference a given item.
 }
 ```
 
+### `test_plan_coverage`
+
+Partition requirements by test plan coverage status.
+
+**Arguments** (all optional):
+- `category` (string): Filter by category (e.g., `"functional"`). An error is returned if the category does not exist.
+
+If no argument is provided, all requirements are included.
+
+**Returns:** Four sorted lists of requirement summaries (each with `id`, `category`, and optionally `short` and `tags`):
+- `no_test_plan`: Requirements with no associated tests
+- `manual_test_plan`: Requirements covered only by manual tests
+- `partially_manual_test_plan`: Requirements covered by a mix of manual and automated tests
+- `automated_test_plan`: Requirements covered exclusively by automated tests
+
+**Examples:**
+```json
+{"name": "test_plan_coverage", "arguments": {}}
+{"name": "test_plan_coverage", "arguments": {"category": "functional"}}
+```
+
+**Response:**
+```json
+{
+  "structuredContent": {
+    "no_test_plan": [
+      {"category": "functional", "id": "RF01"}
+    ],
+    "manual_test_plan": [],
+    "partially_manual_test_plan": [
+      {"category": "functional", "id": "RF02", "short": "Second"}
+    ],
+    "automated_test_plan": [
+      {"category": "non-functional", "id": "RF03", "short": "Number 3", "tags": ["foo", "bar:baz"]}
+    ]
+  }
+}
+```
+
 ### `list_all_tags`
 
 List all tags used across all loaded requirements.

--- a/README.md
+++ b/README.md
@@ -118,4 +118,5 @@ Written 100% by hand (without even a language server):
 Written with LLM assistance:
 - MCP server specification, implementation and related tests
 - [DEVELOPMENT.md](DEVELOPMENT.md), [MCP.md](MCP.md), [AGENTS.md](AGENTS.md)
+- All files in [.claude-plugin](.claude-plugin), [skills](skills)
 - `python/speky/scanner.py`

--- a/README.md
+++ b/README.md
@@ -76,11 +76,32 @@ Requires [uv](https://github.com/astral-sh/uv) >= 0.8.0
    open sphinx/html/index.html
    ```
 
-## Use with an LLM agent (MCP)
+## Use with Claude Code
 
-Requires [uv](https://github.com/astral-sh/uv)
+### 1. Install the plugin
 
-Add to your MCP client's config:
+The plugin adds workflow skills that guide Claude when writing and navigating specifications.
+
+```shell
+/plugin marketplace add agagniere/speky
+/plugin install speky@speky
+```
+
+### 2. Connect the MCP server
+
+The MCP server exposes your project's specifications as queryable tools. Requires [uv](https://github.com/astral-sh/uv).
+
+```shell
+claude mcp add --scope project speky -- uvx --from git+https://github.com/agagniere/speky speky-mcp speky.yaml
+```
+
+Replace `speky.yaml` with the path to your manifest, or list individual YAML/TOML specification files.
+
+> **Note:** If you don't have a specification yet, the `/write-specs` skill will guide you through creating one and configuring the MCP server automatically.
+
+## Use with other MCP clients
+
+Requires [uv](https://github.com/astral-sh/uv). Add to your client's config:
 
 ```json
 {
@@ -94,12 +115,6 @@ Add to your MCP client's config:
 ```
 
 Replace `speky.yaml` with the path to your manifest, or list individual YAML/TOML specification files.
-
-For Claude Code specifically:
-
-```shell
-claude mcp add --scope project speky -- uvx --from git+https://github.com/agagniere/speky speky-mcp speky.yaml
-```
 
 ## Used by
 

--- a/python/speky_mcp/tools.py
+++ b/python/speky_mcp/tools.py
@@ -249,38 +249,113 @@ def handle_list_all_tags(arguments: dict, specs: Specification) -> dict:
 
 TOOL_REGISTRY: dict[str, dict] = {
     'get_requirement': {
-        'description': 'Get a requirement by ID',
-        'inputSchema': {'type': 'object', 'properties': {'id': {'type': 'string'}}, 'required': ['id']},
+        'description': (
+            'Get the full details of a requirement by ID, including its description, tags, '
+            'referenced requirements, tests that cover it, comments, and code references.'
+        ),
+        'inputSchema': {
+            'type': 'object',
+            'properties': {'id': {'type': 'string', 'description': "Requirement ID (e.g. 'RF01')"}},
+            'required': ['id'],
+        },
         'handler': handle_get_requirement,
     },
     'get_test': {
-        'description': 'Get a test by ID',
-        'inputSchema': {'type': 'object', 'properties': {'id': {'type': 'string'}}, 'required': ['id']},
+        'description': (
+            'Get the full details of a test by ID, including its description, steps, '
+            'prerequisites, requirements it covers, and code references.'
+        ),
+        'inputSchema': {
+            'type': 'object',
+            'properties': {'id': {'type': 'string', 'description': "Test ID (e.g. 'T01')"}},
+            'required': ['id'],
+        },
         'handler': handle_get_test,
     },
     'search_requirements': {
-        'description': 'Search requirements, optionally filtering by tag and/or category',
-        'inputSchema': {'type': 'object', 'properties': {'tag': {'type': 'string'}, 'category': {'type': 'string'}}},
+        'description': (
+            'Search and filter requirements by tag and/or category. '
+            'Returns summary entries; use get_requirement for full details. '
+            'Call with no arguments to list all requirements.'
+        ),
+        'inputSchema': {
+            'type': 'object',
+            'properties': {
+                'tag': {
+                    'type': 'string',
+                    'description': (
+                        "Filter by tag, exact match (e.g. 'security' or 'output:pdf'). "
+                        'Use list_all_tags to discover available tags. '
+                        'Returns an error if the tag does not exist.'
+                    ),
+                },
+                'category': {
+                    'type': 'string',
+                    'description': (
+                        "Filter by category (e.g. 'functional'). "
+                        'Returns an error if the category does not exist.'
+                    ),
+                },
+            },
+        },
         'handler': handle_search_requirements,
     },
     'search_tests': {
-        'description': 'Search tests, optionally filtering by category and/or requirement ID',
+        'description': (
+            'Search and filter tests by category and/or the requirement they cover. '
+            'Returns summary entries; use get_test for full details. '
+            'Call with no arguments to list all tests.'
+        ),
         'inputSchema': {
             'type': 'object',
-            'properties': {'category': {'type': 'string'}, 'tester_of': {'type': 'string'}},
+            'properties': {
+                'category': {
+                    'type': 'string',
+                    'description': (
+                        "Filter by category (e.g. 'functional'). "
+                        'Returns an error if the category does not exist.'
+                    ),
+                },
+                'tester_of': {
+                    'type': 'string',
+                    'description': (
+                        'Filter by requirement ID — returns only tests that reference '
+                        'that requirement in their ref field. '
+                        'Returns an error if the requirement ID does not exist.'
+                    ),
+                },
+            },
         },
         'handler': handle_search_tests,
     },
     'list_references_to': {
-        'description': 'List all requirements and tests that reference a given ID',
-        'inputSchema': {'type': 'object', 'properties': {'id': {'type': 'string'}}, 'required': ['id']},
+        'description': 'List all requirements and tests that reference a given ID in their ref field.',
+        'inputSchema': {
+            'type': 'object',
+            'properties': {
+                'id': {'type': 'string', 'description': 'Requirement or test ID to look up.'},
+            },
+            'required': ['id'],
+        },
         'handler': handle_list_references_to,
     },
     'test_plan_coverage': {
-        'description': 'Partition requirements by test plan coverage: no tests, manual only, partially automated, or fully automated',
+        'description': (
+            'Partition requirements into four coverage buckets based on their associated tests: '
+            'no tests, manual tests only, partially automated, or fully automated. '
+            'Useful for identifying requirements with no test plan.'
+        ),
         'inputSchema': {
             'type': 'object',
-            'properties': {'category': {'type': 'string'}},
+            'properties': {
+                'category': {
+                    'type': 'string',
+                    'description': (
+                        "Restrict the report to one category (e.g. 'functional'). "
+                        'Returns an error if the category does not exist.'
+                    ),
+                },
+            },
         },
         'handler': handle_test_plan_coverage,
     },
@@ -313,12 +388,18 @@ TOOL_REGISTRY: dict[str, dict] = {
         'handler': handle_least_tested_requirements,
     },
     'list_all_tags': {
-        'description': 'List all tags used across all requirements',
+        'description': (
+            'List all tags used across all requirements. '
+            'Use the returned values as inputs to the tag argument of search_requirements.'
+        ),
         'inputSchema': {'type': 'object', 'properties': {}},
         'handler': handle_list_all_tags,
     },
     'list_all_ids': {
-        'description': 'List all requirement and test IDs',
+        'description': (
+            'List all requirement and test IDs present in the loaded specifications. '
+            'Use these as inputs to get_requirement and get_test.'
+        ),
         'inputSchema': {'type': 'object', 'properties': {}},
         'handler': handle_list_all_ids,
     },

--- a/python/speky_mcp/tools.py
+++ b/python/speky_mcp/tools.py
@@ -292,8 +292,7 @@ TOOL_REGISTRY: dict[str, dict] = {
                 'category': {
                     'type': 'string',
                     'description': (
-                        "Filter by category (e.g. 'functional'). "
-                        'Returns an error if the category does not exist.'
+                        "Filter by category (e.g. 'functional'). Returns an error if the category does not exist."
                     ),
                 },
             },
@@ -312,8 +311,7 @@ TOOL_REGISTRY: dict[str, dict] = {
                 'category': {
                     'type': 'string',
                     'description': (
-                        "Filter by category (e.g. 'functional'). "
-                        'Returns an error if the category does not exist.'
+                        "Filter by category (e.g. 'functional'). Returns an error if the category does not exist."
                     ),
                 },
                 'tester_of': {
@@ -360,7 +358,11 @@ TOOL_REGISTRY: dict[str, dict] = {
         'handler': handle_test_plan_coverage,
     },
     'least_tested_requirements': {
-        'description': 'List requirements sorted by ascending test coverage: fewest total test plans first, then fewest automated test plans',
+        'description': (
+            'List requirements ranked by ascending test coverage, returning test_plans and automated_test_plans counts per entry. '
+            'Useful for prioritizing where to write new tests. '
+            'Sort order: fewest total test plans first, then fewest automated test plans, then alphabetically by ID.'
+        ),
         'inputSchema': {
             'type': 'object',
             'properties': {
@@ -390,7 +392,7 @@ TOOL_REGISTRY: dict[str, dict] = {
     'list_all_tags': {
         'description': (
             'List all tags used across all requirements. '
-            'Use the returned values as inputs to the tag argument of search_requirements.'
+            'Use the returned values as inputs to the tag argument of search_requirements or least_tested_requirements.'
         ),
         'inputSchema': {'type': 'object', 'properties': {}},
         'handler': handle_list_all_tags,

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -123,7 +123,24 @@ If no `specs/` directory (or equivalent) exists in the project, ask the user whe
 
 ## Step 7 — Write and validate the first requirement
 
-Write a single requirement from the plan as a Speky TOML file and show it to the user. Ask:
+See `tests/samples/more_requirements.toml` in speky repo for the format,
+and the `sample-req.toml` file bundled in this skill for an example of a good functional requirement.
+
+Requirements from the plan where short summaries, now you can go in more details on what user actions are expected and about observable effects.
+
+For requirements that are rephrased from an existing requirement (not from code),
+include the original requirement (or the most significant excerpt) in the `client_statement` field.
+
+For requirements that come from a webpage, include the URL as a `source` field inside the `properties` of that requirement.
+
+Use tags to allow readers to find a requirement from:
+- its theme
+- the associated system component
+etc
+
+Tags support one level of hierarchy to create sub-groups, e.g. `protocol`, `protocol:http`, `protocol:grpc`
+
+Write a single functional requirement from the plan as a Speky TOML file and show it to the user. Ask:
 
 > "Does this format and phrasing meet your expectations?"
 
@@ -132,6 +149,8 @@ Incorporate any feedback before proceeding. This first requirement sets the styl
 ## Step 8 — Write all requirements
 
 Write all remaining requirements as TOML files. Group them into files of roughly 4–10 requirements each, grouping by category, theme, or functional area. Use one file per group.
+
+Refer to the index .md files created in previous steps to correctly source requirements.
 
 ## Step 9 — Write the manifest
 
@@ -175,3 +194,7 @@ git commit
 ```
 
 Write a commit message that briefly describes what was specified (e.g. "Add initial Speky specification for <project or feature name>").
+
+## Step 13 - Restart
+
+Tell the user to exit then resume their Claude session, to connect to the newly configured MCP server

--- a/skills/init/sample-req.toml
+++ b/skills/init/sample-req.toml
@@ -1,0 +1,33 @@
+kind = "requirements"
+category = "functional"
+
+[[requirements]]
+id = "MCP005"
+short = "Search and filter requirements"
+client_statement = '''
+I would like to discover what requirements exist by searching with filters like tags or categories.
+For example, "show me all requirements tagged with 'security'" or "what functional requirements exist?"
+This helps me explore the specification and find related requirements when working on a feature.
+'''
+long = '''
+The user shall be able to search for requirements using optional filter criteria.
+
+The MCP server shall expose a tool named `search_requirements` that accepts
+optional filter parameters and returns matching requirements.
+
+Filter parameters:
+- `tag`: Filter by tag (exact match, e.g., "input" or "output:pdf"). If the tag does not exist in the loaded specifications, an error shall be returned.
+- `category`: Filter by category (exact match, e.g., "functional"). If the category does not exist in the loaded specifications, an error shall be returned.
+
+If no filters are provided, all requirements shall be returned.
+
+The response shall be a list of requirement summaries, each containing:
+- `id`: The unique identifier
+- `short`: The short description (if present)
+- `category`: The requirement category
+- `tags`: List of tags (if present)
+
+The list shall be sorted alphabetically by ID.
+'''
+tags = ["mcp:tools", "mcp:discovery"]
+properties = { author = "Claude", source = "https://example.com" }

--- a/skills/speky-workflow/SKILL.md
+++ b/skills/speky-workflow/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: speky-workflow
+description: Guidelines for working with Speky requirements and tests via the speky MCP server tools
+when_to_use: When working with requirements, tests, specifications, or using any speky MCP tools (get_requirement, get_test, search_requirements, search_tests, list_all_ids, list_all_tags, list_references_to, test_plan_coverage)
+user-invocable: false
+---
+
+# Speky Workflow Guidelines
+
+Speky organizes a project's detailed specification into **requirements** (what the system must do) and **tests** (how to verify it). Items are identified by short IDs like `RF01`, `RNF02`, `T03`.
+
+## Tool selection
+
+- Start with `list_all_ids` to get a full overview of available IDs before searching or fetching.
+- Use `get_requirement` / `get_test` when you already know the ID — it's faster and returns full detail including cross-references.
+- Use `search_requirements` only when filtering by tag or category. Use `search_tests` only when filtering by category or by requirement (`tester_of`). Do not call either with no filters as a substitute for `list_all_ids`.
+- Use `list_all_tags` to discover available tags before filtering by one.
+- Use `list_references_to` to find what depends on a given item (e.g., before modifying or deleting it).
+- Use `test_plan_coverage` to find coverage gaps — it gives a project-wide summary without requiring manual inspection.
+
+## Reading results
+
+- `get_requirement` returns `tested_by` (tests covering it) and `referenced_by` (requirements that depend on it). Read these before assessing coverage or impact.
+- `get_test` returns `ref` (requirements it validates) and `prereq` (tests that must run first). Read these to understand test scope and ordering.
+- Tags use a namespaced format: `namespace:value` (e.g., `output:pdf`, `mcp:tools`). When filtering by tag, use the exact full string.
+
+## Working with coverage
+
+- A requirement is covered if it appears in at least one test's `ref` list (visible as `tested_by` on the requirement).
+- Use `test_plan_coverage` for a project-wide summary before concluding anything about overall coverage.
+- Do not infer coverage from description alone — always check `tested_by`.
+
+## Writing test plans
+
+- Think about prerequisites first: "how to reach a state where the feature can be tested simply?" Structure tests so that later tests can build on the final state of earlier ones, using the `prereq` field rather than repeating setup steps.
+- Be as specific as possible: include relevant excerpts of inputs and outputs as `sample` fields on steps.
+- `expected` is only for listing (an excerpt of) the output of a `run` command. Do not use it for steps that have no `run`.
+
+## Building a new feature
+
+Follow this order strictly:
+1. Write the requirements in Speky YAML
+2. Write the test plan (Speky functional tests)
+3. Implement the tests as executable code where possible
+4. Write the implementation until the tests pass
+
+## Requirement categories
+
+Category is a free-form field, but four values cover most cases:
+
+| Category | Intent | Test plan |
+|---|---|---|
+| `functional` | User-facing behavior: "The user shall be able to …" | Primary focus of test plans |
+| `non-functional` | System-level constraint: "The system shall … (e.g. handle 100k tps, respond in < 1ms)" | Test if measurable, otherwise document |
+| `architecture` | Represents an architectural decision | Not tested |
+| `definition` | Defines a project-specific term, referenced from other requirements to avoid duplication | Not tested |
+
+When writing requirements, pick the category that reflects the *intent*, not just the wording.
+
+## Adding or modifying specifications
+
+- Requirements and tests are defined in YAML or TOML files, which can be placed anywhere, usually under `specs/`.
+- The manifest (`specs/speky.yaml` or similar) lists which files to load — new files must be referenced there.
+- After editing spec files, the MCP server must be restarted to pick up changes (it loads specs at startup).
+- IDs must be unique across the entire loaded specification set.

--- a/skills/speky-workflow/SKILL.md
+++ b/skills/speky-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: speky-workflow
 description: Guidelines for working with Speky requirements and tests via the speky MCP server tools
-when_to_use: When working with requirements, tests, specifications, or using any speky MCP tools (get_requirement, get_test, search_requirements, search_tests, list_all_ids, list_all_tags, list_references_to, test_plan_coverage)
+when_to_use: When working with requirements, tests, specifications, or using any speky MCP tools (get_requirement, get_test, search_requirements, search_tests, list_all_ids, list_all_tags, list_references_to, test_plan_coverage, least_tested_requirements)
 user-invocable: false
 ---
 
@@ -17,6 +17,7 @@ Speky organizes a project's detailed specification into **requirements** (what t
 - Use `list_all_tags` to discover available tags before filtering by one.
 - Use `list_references_to` to find what depends on a given item (e.g., before modifying or deleting it).
 - Use `test_plan_coverage` to find coverage gaps — it gives a project-wide summary without requiring manual inspection.
+- Use `least_tested_requirements` to find where to write new tests — it ranks requirements by ascending test count and accepts `tag`, `category`, and `count` filters.
 
 ## Reading results
 
@@ -28,6 +29,7 @@ Speky organizes a project's detailed specification into **requirements** (what t
 
 - A requirement is covered if it appears in at least one test's `ref` list (visible as `tested_by` on the requirement).
 - Use `test_plan_coverage` for a project-wide summary before concluding anything about overall coverage.
+- Use `least_tested_requirements` (with optional `tag` or `category` filter) to pinpoint the requirements most in need of new tests.
 - Do not infer coverage from description alone — always check `tested_by`.
 
 ## Writing test plans

--- a/skills/speky-workflow/SKILL.md
+++ b/skills/speky-workflow/SKILL.md
@@ -7,7 +7,7 @@ user-invocable: false
 
 # Speky Workflow Guidelines
 
-Speky organizes a project's detailed specification into **requirements** (what the system must do) and **tests** (how to verify it). Items are identified by short IDs like `RF01`, `RNF02`, `T03`.
+Speky organizes a project's detailed specification into **requirements** (what the system must do) and **tests** (how to verify it). Items are identified by short IDs like `RF001`, `RN02`, `T003`.
 
 ## Tool selection
 

--- a/skills/write-specs/SKILL.md
+++ b/skills/write-specs/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: write-specs
+description: Interactive workflow for writing Speky specifications (requirements + test plan) for an existing project
+user-invocable: true
+disable-model-invocation: false
+argument-hint: "[path to project root, defaults to current directory]"
+---
+
+You are helping the user write a formal Speky specification for an existing project. Follow these steps in order, waiting for user input where indicated.
+
+## Step 1 — Identify relevant files
+
+Explore the project at $ARGUMENTS (or the current directory if not provided).
+
+Identify files that reveal intent, behavior, or constraints:
+- Source code (focus on public interfaces, entry points, core logic — not boilerplate)
+- Existing documentation (README, docs/, wikis)
+- Configuration files that define behavior
+- Tests (they often describe expected behavior explicitly)
+- Changelogs or ADRs if present
+
+## Step 2 — Write a file index
+
+Write a temporary file at `/tmp/speky-index-${CLAUDE_SESSION_ID}.md` with the following structure:
+
+```markdown
+# Project File Index
+
+## Source files
+| File | Summary |
+|------|---------|
+| `path/to/file.py` | One-line description of what behavior/feature it contains |
+...
+
+## Documentation
+| File | Summary |
+|------|---------|
+...
+
+## Tests
+| File | Summary |
+|------|---------|
+...
+```
+
+Include the full relative path for every file — it will be used later to trace requirements back to source. Omit files with no behavioral content (lockfiles, assets, generated code, etc.).
+
+Tell the user the index has been written to `/tmp/speky-index-${CLAUDE_SESSION_ID}.md`.
+
+## Step 3 — Ask for external sources
+
+Ask the user:
+
+> "Are there any external sources of requirements or specifications I should consider? (e.g. a product brief, a standards document, a public API spec, a user story map — please share URLs or file paths)"
+
+If the user provides sources:
+- Fetch or read each one
+- Write a temporary file at `/tmp/speky-sources-${CLAUDE_SESSION_ID}.md`:
+
+```markdown
+# External Sources
+
+## [Document title](URL or path)
+### [Section name](URL#anchor or path:line)
+One-paragraph summary of what requirements or constraints this section implies.
+
+### [Next section](...)
+...
+```
+
+Include the URL or file path for every section — it will be used to justify requirements. Tell the user this file has been written.
+
+If the user has no external sources, continue to the next step.
+
+## Step 4 — Propose requirements and iterate
+
+Using the file index and external sources, draft a list of requirements. For each requirement, write:
+
+```
+[ID draft] [category] — Short title
+  > Long description
+  > Source: `path/to/file.py` or [Section](URL)
+```
+
+Choose the category that reflects the *intent*:
+- `functional` — user-facing behavior ("The user shall be able to …"). These are the main focus of test plans.
+- `non-functional` — system-level constraint ("The system shall …", e.g. performance, reliability).
+- `architecture` — an architectural decision. Not tested.
+- `definition` — defines a project-specific term referenced from other requirements. Not tested.
+
+Also look for implicit definitions and architectural decisions in the code — not just functional behaviors. They deserve their own requirements too.
+
+**Writing good requirements:** A requirement should be precise enough to be unambiguous, but silent on how it is implemented. For functional requirements in particular, describe what the user does to trigger the behavior and what observable effect results — not what happens inside the system.
+
+Group them by theme. Present the full list to the user and ask:
+
+> "Does this list look right? What should be added, removed, rephrased, or split?"
+
+Iterate — revise the list based on feedback — until the user is satisfied.
+
+## Step 5 — Save as a plan
+
+Once the user approves the list, write the final requirements as a plan file at `/tmp/speky-plan-${CLAUDE_SESSION_ID}.md`:
+
+```markdown
+# Requirements Plan
+
+## [Theme name]
+
+### [ID draft] — [Short title]
+- **Category:** functional | non-functional | architecture | definition
+- **Description:** Full requirement text
+- **Source:** `path/to/file` or [Section title](URL)
+
+...
+```
+
+Tell the user the plan has been saved to `/tmp/speky-plan-${CLAUDE_SESSION_ID}.md`, then continue with the steps below.
+
+## Step 6 — Determine where to store the specification
+
+If no `specs/` directory (or equivalent) exists in the project, ask the user where they want to store the specification files.
+
+## Step 7 — Write and validate the first requirement
+
+Write a single requirement from the plan as a Speky TOML file and show it to the user. Ask:
+
+> "Does this format and phrasing meet your expectations?"
+
+Incorporate any feedback before proceeding. This first requirement sets the style for all the rest.
+
+## Step 8 — Write all requirements
+
+Write all remaining requirements as TOML files. Group them into files of roughly 4–10 requirements each, grouping by category, theme, or functional area. Use one file per group.
+
+## Step 9 — Write the manifest
+
+Create a Speky manifest file at `specs/speky.yaml` listing all the requirement files written in the previous step.
+
+## Step 10 — Configure the MCP server
+
+Add or update `.mcp.json` at the project root to load the new manifest:
+
+```json
+{
+  "mcpServers": {
+    "speky": {
+      "command": "uvx",
+      "args": ["--from", "git+https://github.com/agagniere/speky", "speky-mcp", "specs/speky.yaml"]
+    }
+  }
+}
+```
+
+Replace the manifest path if it differs.
+
+## Step 11 — Validate
+
+Run speky to validate the specification:
+
+```bash
+uvx --from git+https://github.com/agagniere/speky speky specs/speky.yaml --check-only
+```
+
+Fix any validation errors before finishing.
+
+## Step 12 — Commit
+
+Stage and commit all new specification files:
+
+```bash
+git add specs/
+git add .mcp.json
+git commit
+```
+
+Write a commit message that briefly describes what was specified (e.g. "Add initial Speky specification for <project or feature name>").

--- a/skills/write-test-plans/SKILL.md
+++ b/skills/write-test-plans/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: write-test-plans
+description: Interactive workflow for writing new Speky test plans for requirements lacking coverage, guided by the Speky MCP server
+user-invocable: true
+argument-hint: "[area of interest, e.g. 'search', 'authentication', 'file output']"
+---
+
+You are helping the user expand their project's test plan coverage for a specific area. Follow these steps in order.
+
+## Step 1 — Identify the area of interest
+
+If `$ARGUMENTS` is provided, use it as the area of interest (e.g. `"search"`, `"authentication"`, `"file output"`).
+
+Otherwise ask the user:
+> "What area or feature would you like to focus on? (e.g. a functional area, a component name, or a keyword)"
+
+## Step 2 — Discover relevant tags
+
+Call `list_all_tags` to retrieve all tags used in the specification.
+
+From the returned list, select all tags that relate to the area of interest. Use the full tag string including namespace (e.g. `mcp:tools`, not just `tools`).
+
+Tell the user which tags you selected and why, and ask them to confirm or adjust before continuing:
+> "I identified these tags as relevant: `tag-a`, `tag-b`. Does that look right, or would you like to add or remove any?"
+
+## Step 3 — Find requirements needing test plans
+
+For each selected tag, call `least_tested_requirements` with that tag and `count: 3`. Merge and deduplicate the results across all tags, then sort by `test_plans` ascending (then `automated_test_plans` ascending). Keep the top 3.
+
+Tell the user which requirements you will write test plans for, and wait for their approval before proceeding.
+
+## Step 4 — Study each target requirement
+
+For each target requirement, gather full context before designing anything:
+
+1. Call `get_requirement` — read its `long` description, `tags`, `ref`, `referenced_by`, and `tested_by`. Note the `source_file` field: it tells you which spec file the requirement lives in, which determines where the test file will go.
+2. For each ID in `ref` and `referenced_by`, call `get_requirement` to understand related requirements and shared context.
+3. For each ID in `tested_by` (if any), call `get_test` to understand what is already tested — avoid designing scenarios that duplicate existing tests.
+
+## Step 5 — Design new test scenarios
+
+Using what you learned, design **2 to 5 new test scenarios** per requirement. Think across these angles:
+
+- **Minimal happy path** — the simplest possible demonstration that the feature works as intended (doubles as documentation)
+- **Complex happy path** — exercises the feature more completely, combining multiple inputs or options
+- **Invalid inputs** — what happens when the user passes something wrong; verify the system handles it properly
+- **Failure conditions** — external failures such as file not found, query error, missing dependency, or permission denied
+- **Untested combinations** — input pairings or states that existing tests do not yet cover
+
+For each scenario, determine the **initial state**:
+- If it naturally starts from the final state of an existing test, list that test in `prereq`.
+- If several new scenarios share the same non-trivial setup, consider writing one dedicated setup test and listing it as a `prereq` for all of them.
+- If the initial state just requires specific tools or files to be present, describe that plainly in the `initial` field.
+
+## Step 6 — Write the test files
+
+For each target requirement `<ID>`:
+
+1. Derive the test file path from `source_file`: take its parent directory, append `tests/`, and name the file `test_<ID>.toml`. For example, if `source_file` is `specs/mcp/query.yaml`, write to `specs/mcp/tests/test_MCP005.toml`; if it is `specs/functional.yaml`, write to `specs/tests/test_F012.toml`.
+2. Write all new scenarios for that requirement into that single file.
+
+Use TOML format:
+
+```toml
+kind = "tests"
+category = "functional"  # match the category of the requirement
+
+[[tests]]
+id = "T<NNN>"
+short = "Brief scenario title"
+long = "What this scenario validates and why it is interesting"
+ref = ["<ID>"]            # the requirement this test covers
+prereq = ["T<previous>"]  # omit if not applicable
+initial = """
+- Tool X must be available
+- File foo.yaml must exist in the current directory
+"""
+
+[[tests.steps]]
+action = "Description of what the user does"
+run = "shell command if applicable"
+expected = "excerpt of expected output (only when a run command is present)"
+
+[[tests.steps]]
+action = "Next step"
+sample_lang = "json"
+sample = """
+{"key": "value"}
+"""
+```
+
+Assign IDs that continue from the highest existing test ID in the project. If unsure of the highest, call `list_all_ids` to check.
+
+## Step 7 — Update the manifest
+
+Open the project manifest (typically `specs/speky.yaml`, `specs/mcp/mcp.toml`, or similar).
+
+Check whether it already includes a glob pattern that would match the new test files (e.g. `specs/tests/*.toml`). If not, add the appropriate pattern to the `files` list.
+
+## Step 8 — Validate
+
+Run speky on the manifest to validate the newly written tests:
+
+```bash
+uvx --from git+https://github.com/agagniere/speky speky <manifest-path> --check-only
+```
+
+Fix any validation errors before continuing.
+
+## Step 9 — Commit
+
+Stage and commit:
+
+```bash
+git add specs/
+git commit
+```
+
+Write a commit message naming the requirements being covered, e.g. `"Add test plans for MCP005, MCP007"`.
+
+## Step 10 — Restart MCP
+
+Tell the user:
+
+> "The new test plans have been committed. **Restart the MCP server** (exit and resume your Claude session) so the server picks up the changes."


### PR DESCRIPTION
Add a passive skill for LLMs to best use Speky's features, and 2 user skills:
- `init` to onboard an existing project to Speky (write initial set of requirements and set up the MCP server)
- `write-test-plans` to write more speky tests of existing requirements