### PR TITLE
Mention the number of test plans in the coverage report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,11 @@ The project has two Python packages under `python/`:
 - `specification.py` — Loads YAML/TOML files and `kind: project` manifests, resolves cross-references, scans source code for `speky:<project>#<ID>` tags, computes test-plan coverage
 - `models.py` — `Requirement`, `Test`, `Comment`, `Manifest`, `SourceLinkConfig` data models. Requirements and tests accept an optional `code` field (list of `{file, symbol?, line?, is_test?}` entries) to declare code references from the spec without writing `speky:<name>#<ID>` tags in the source.
 - `scanner.py` — Tree-sitter based scanner extracting code references from Python/Go/Rust/Bash sources. Also hosts `build_declared_reference` / `find_symbol`, which turn declarative `code` entries into `CodeReference` objects by resolving the named symbol via tree-sitter.
-- `generators/markdown.py` — MyST Markdown output. The generated `coverage.md` page groups requirements into Automated / Partially Manual / Manual / No Test Plan dropdowns and annotates each entry with its total test-plan count and how many of those are automated (e.g. `RF01 — 3 test plans, 2 automated`).
+- `generators/markdown.py` — MyST Markdown output. The generated `coverage.md` page groups requirements into Automated / Partially Manual / Manual / No Test Plan dropdowns. Each entry is annotated based on its bucket:
+  - **No Test Plan**: plain link only (e.g. `[RF01](/requirements/RF01)`)
+  - **Manual**: `[RF01](/requirements/RF01) — 4 test plans`
+  - **Partially Manual**: `[RF01](/requirements/RF01) — 2/4 test plans automated`
+  - **Automated**: `[RF01](/requirements/RF01) — 4 automated test plans`
 - `utils.py`, `log_formatter.py` — Field-import helpers and CLI log formatting
 - `assets/` — Default `logging.yaml` config and `speky.css` copied into the generated Markdown folder
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,9 +50,9 @@ The project has two Python packages under `python/`:
 ### `speky` — CLI tool
 - `main.py` — Argument parsing and orchestration
 - `specification.py` — Loads YAML/TOML files and `kind: project` manifests, resolves cross-references, scans source code for `speky:<project>#<ID>` tags, computes test-plan coverage
-- `models.py` — `Requirement`, `Test`, `Comment`, `Manifest`, `SourceLinkConfig` data models
-- `scanner.py` — Tree-sitter based scanner extracting code references from Python/Go/Rust/Bash sources
-- `generators/markdown.py` — MyST Markdown output
+- `models.py` — `Requirement`, `Test`, `Comment`, `Manifest`, `SourceLinkConfig` data models. Requirements and tests accept an optional `code` field (list of `{file, symbol?, line?, is_test?}` entries) to declare code references from the spec without writing `speky:<name>#<ID>` tags in the source.
+- `scanner.py` — Tree-sitter based scanner extracting code references from Python/Go/Rust/Bash sources. Also hosts `build_declared_reference` / `find_symbol`, which turn declarative `code` entries into `CodeReference` objects by resolving the named symbol via tree-sitter.
+- `generators/markdown.py` — MyST Markdown output. The generated `coverage.md` page groups requirements into Automated / Partially Manual / Manual / No Test Plan dropdowns and annotates each entry with its total test-plan count and how many of those are automated (e.g. `RF01 — 3 test plans, 2 automated`).
 - `utils.py`, `log_formatter.py` — Field-import helpers and CLI log formatting
 - `assets/` — Default `logging.yaml` config and `speky.css` copied into the generated Markdown folder
 

--- a/python/speky/generators/markdown.py
+++ b/python/speky/generators/markdown.py
@@ -202,6 +202,25 @@ _BUCKET_LABELS = ['Automated', 'Partially Manual', 'Manual', 'No Test Plan']
 _BUCKET_ICONS = ['check-circle-fill', 'gear', 'pencil', 'x-circle-fill']
 
 
+def coverage_item(requirement, specs) -> str:
+    link = link_to(requirement)
+    tests = specs.testers_of.get(requirement.id, [])
+    total = len(tests)
+    if not total:
+        return link
+    automated = sum(1 for t in tests if specs.is_test_automated(t.id))
+    plan_word = 'plan' if total == 1 else 'plans'
+    return f'{link} — {total} test {plan_word}, {automated} automated'
+
+
+def write_coverage_list(output: MarkdownWriter, items: list, specs):
+    if len(items) == 1:
+        output.write_line(coverage_item(items[0], specs))
+    else:
+        for item in sorted(items):
+            output.write_line(f'- {coverage_item(item, specs)}')
+
+
 def coverage_to_myst(specs, folder_name: str):
     with open(os.path.join(folder_name, 'coverage.md'), encoding='utf8', mode='w') as f:
         output = MystWriter(f)
@@ -220,7 +239,7 @@ def coverage_to_myst(specs, folder_name: str):
                 ):
                     title = f'{label} ({len(items)} — {len(items) / total:.0%})'
                     with output.dropdown(0, title, color if items else 'secondary', False, icon) as dropdown:
-                        write_list_of_links(dropdown, items)
+                        write_coverage_list(dropdown, items, specs)
             output.empty_line()
 
 

--- a/python/speky/generators/markdown.py
+++ b/python/speky/generators/markdown.py
@@ -210,7 +210,11 @@ def coverage_item(requirement, specs) -> str:
         return link
     automated = sum(1 for t in tests if specs.is_test_automated(t.id))
     plan_word = 'plan' if total == 1 else 'plans'
-    return f'{link} — {total} test {plan_word}, {automated} automated'
+    if automated == total:
+        return f'{link} — {total} automated test {plan_word}'
+    if automated == 0:
+        return f'{link} — {total} test {plan_word}'
+    return f'{link} — {automated}/{total} test {plan_word} automated'
 
 
 def write_coverage_list(output: MarkdownWriter, items: list, specs):

--- a/tests/test_markdown_coverage.py
+++ b/tests/test_markdown_coverage.py
@@ -1,0 +1,120 @@
+"""Tests for coverage_item and write_coverage_list in the markdown generator."""
+
+from io import StringIO
+from types import SimpleNamespace
+
+from speky.generators.markdown import MarkdownWriter, coverage_item, write_coverage_list
+
+
+class StubRequirement:
+    folder = 'requirements'
+
+    def __init__(self, req_id: str):
+        self.id = req_id
+        self.title = f'`{req_id}`'
+
+    def __lt__(self, other):
+        return self.id < other.id
+
+
+def make_requirement(req_id: str) -> StubRequirement:
+    return StubRequirement(req_id)
+
+
+def make_test(test_id: str) -> SimpleNamespace:
+    return SimpleNamespace(id=test_id)
+
+
+def make_specs(tests_by_req: dict[str, list], automated_ids: set[str]):
+    """Build a minimal specs stub for coverage_item tests."""
+    testers_of = {req_id: [make_test(t) for t in test_ids] for req_id, test_ids in tests_by_req.items()}
+    return SimpleNamespace(
+        testers_of=testers_of,
+        is_test_automated=lambda test_id: test_id in automated_ids,
+    )
+
+
+class TestCoverageItem:
+    def test_no_tests_returns_link_only(self):
+        req = make_requirement('RF01')
+        specs = make_specs({}, set())
+        result = coverage_item(req, specs)
+        assert result == '[`RF01`](/requirements/RF01)'
+
+    def test_single_automated_test(self):
+        req = make_requirement('RF01')
+        specs = make_specs({'RF01': ['T01']}, {'T01'})
+        result = coverage_item(req, specs)
+        assert '1 automated test plan' in result
+        assert '`RF01`' in result
+
+    def test_multiple_automated_tests(self):
+        req = make_requirement('RF01')
+        specs = make_specs({'RF01': ['T01', 'T02', 'T03']}, {'T01', 'T02', 'T03'})
+        result = coverage_item(req, specs)
+        assert '3 automated test plans' in result
+
+    def test_single_manual_test(self):
+        req = make_requirement('RF01')
+        specs = make_specs({'RF01': ['T01']}, set())
+        result = coverage_item(req, specs)
+        assert '1 test plan' in result
+        assert 'automated' not in result
+
+    def test_multiple_manual_tests(self):
+        req = make_requirement('RF01')
+        specs = make_specs({'RF01': ['T01', 'T02']}, set())
+        result = coverage_item(req, specs)
+        assert '2 test plans' in result
+        assert 'automated' not in result
+
+    def test_partial_automation(self):
+        req = make_requirement('RF01')
+        specs = make_specs({'RF01': ['T01', 'T02', 'T03']}, {'T01', 'T02'})
+        result = coverage_item(req, specs)
+        assert '2/3 test plans automated' in result
+
+    def test_singular_plan_word(self):
+        req = make_requirement('RF01')
+        specs = make_specs({'RF01': ['T01']}, {'T01'})
+        assert 'test plan' in coverage_item(req, specs)
+        assert 'test plans' not in coverage_item(req, specs)
+
+    def test_plural_plan_word(self):
+        req = make_requirement('RF01')
+        specs = make_specs({'RF01': ['T01', 'T02']}, {'T01', 'T02'})
+        assert 'test plans' in coverage_item(req, specs)
+
+
+class TestWriteCoverageList:
+    def _capture(self, items, specs):
+        buf = StringIO()
+        write_coverage_list(MarkdownWriter(buf), items, specs)
+        return buf.getvalue()
+
+    def test_empty_list_writes_nothing(self):
+        specs = make_specs({}, set())
+        assert self._capture([], specs) == ''
+
+    def test_single_item_no_bullet(self):
+        req = make_requirement('RF01')
+        specs = make_specs({'RF01': ['T01']}, {'T01'})
+        output = self._capture([req], specs)
+        assert not output.startswith('-')
+        assert '`RF01`' in output
+
+    def test_multiple_items_with_bullets(self):
+        reqs = [make_requirement('RF01'), make_requirement('RF02')]
+        specs = make_specs({'RF01': ['T01'], 'RF02': ['T02']}, {'T01', 'T02'})
+        output = self._capture(reqs, specs)
+        lines = [line for line in output.splitlines() if line]
+        assert all(line.startswith('- ') for line in lines)
+        assert len(lines) == 2
+
+    def test_multiple_items_sorted(self):
+        reqs = [make_requirement('RF02'), make_requirement('RF01')]
+        specs = make_specs({}, set())
+        output = self._capture(reqs, specs)
+        lines = [line for line in output.splitlines() if line]
+        assert 'RF01' in lines[0]
+        assert 'RF02' in lines[1]


### PR DESCRIPTION
Format:
- **No Test Plan**: plain link only (e.g. `[RF01](/requirements/RF01)`)
- **Manual**: `[RF01](/requirements/RF01)` — 4 test plans
- **Partially Manual**: `[RF01](/requirements/RF01)` — 2/4 test plans automated
- **Automated**: `[RF01](/requirements/RF01)` — 4 automated test plans